### PR TITLE
Make instrumented functions be marked with special property

### DIFF
--- a/packages/taintflow-runtime/src/reflection.ts
+++ b/packages/taintflow-runtime/src/reflection.ts
@@ -1,5 +1,6 @@
 export namespace reflection {
+    const functionToString = Function.prototype.toString;
     export function isInstrumented(f: Function) {
-        return !/{ \[native code\] }$/.test(f.toString());
+        return !/{ \[native code\] }$/.test(functionToString.call(f)) || Object.prototype.hasOwnProperty.call(f, '0-tf-instrumented-1');
     }
 }


### PR DESCRIPTION
This is needed for DOM XSS sink tracking implementation via Proxy 
Also Function.prototype.toString reference is stored separately now to avoid it's redefinition inside the instrumented code.