### PR TITLE
Turn off boolean objects taint-wrappping

### DIFF
--- a/packages/taintflow-runtime/src/tainter/interception/PropagationStrategy.ts
+++ b/packages/taintflow-runtime/src/tainter/interception/PropagationStrategy.ts
@@ -29,8 +29,11 @@ export class PropagationStrategy {
         if (!flow) {
             return result;
         }
+        const val = result.value;
+        if (typeof val === 'boolean') {
+            return result;
+        }
         if (result instanceof PropertyReference) {
-            const val = result.value;
             if (val instanceof Boxed && val.flow) {
                 return wrap(result, (value) => val.flow.alter(value).watch());
             }


### PR DESCRIPTION
It forces conditional operators to be confused