### PR TITLE
Change propagation strategy 

### DIFF
--- a/packages/taintflow-runtime/src/tainter/interception/PropagationStrategy.ts
+++ b/packages/taintflow-runtime/src/tainter/interception/PropagationStrategy.ts
@@ -50,17 +50,24 @@ export class PropagationStrategy {
             if (val instanceof Boxed && val.flow) {
                 return wrap(
                     result,
-                    (value) => val.flow.alter(value).watch(),
+                    this.defaultWrapper(val.flow),
                     baseWrapper
                 );
             }
             return wrap(
                 result,
-                (value) => flow.alter(value).watch(),
+                this.defaultWrapper(flow),
                 baseWrapper
             );
         }
-        return wrap(result, (value) => flow.alter(value).watch());
+        return wrap(result, this.defaultWrapper(flow));
+    }
+
+    private defaultWrapper<T>(flow: Flow<Mixed>) {
+        return (value: T) =>
+            (this.shouldReleaseArguments && Array.isArray(value))
+                ? <T><Mixed> value.map((e) => flow.alter(e).watch())
+                : flow.alter(value).watch();
     }
 
     private attachMember(node: nodes.MemberNode): typeof node {

--- a/packages/taintflow-runtime/src/tainter/interception/wrap.ts
+++ b/packages/taintflow-runtime/src/tainter/interception/wrap.ts
@@ -9,10 +9,10 @@ import {
 export type Wrapper<T> = (value: T) => T;
 export type Callback<T> = (value: T) => T;
 
-export function wrap<T>(
+export function wrap<T, Base>(
     evaluated: EvaluatedExpression<T>,
     wrapper: Wrapper<T>,
-    baseWrapper?: Wrapper<T>,
+    baseWrapper?: Wrapper<Base>,
 ): typeof evaluated {
     switch (evaluated.kind) {
         case ValueKind.RValue:

--- a/packages/taintflow-runtime/test/tainter/Flow.spec.ts
+++ b/packages/taintflow-runtime/test/tainter/Flow.spec.ts
@@ -47,7 +47,7 @@ describe("Flow", () => {
 
         it("should propagate after the method call", () => {
             run(() => {
-                return Flow.of(Flow.tainted("a#b").split("#")).isTainted;
+                return Flow.of(Flow.tainted("a1#b2").slice(3)).isTainted;
             }).should.be.true;
         });
 
@@ -112,9 +112,19 @@ describe("Flow", () => {
                 Flow.tainted({
                     foo() {
                         global = this;
-                    }
+                    },
                 }).foo();
                 return Flow.of(global).isTainted;
+            }).should.be.true;
+        });
+    });
+
+    context("native methods", () => {
+        it("should not taint Array return value but taint each of Array elements", () => {
+            run(() => {
+                return Flow.tainted("a#b")
+                    .split("#")
+                    .every((x) => Flow.of(x).isTainted);
             }).should.be.true;
         });
     });


### PR DESCRIPTION
for Arrays being returned from native methods.
Now we taint each of the array elements instead of whole Array object.
